### PR TITLE
ci: tag reviewers explicitly

### DIFF
--- a/.github/workflows/update-charm-tests.yaml
+++ b/.github/workflows/update-charm-tests.yaml
@@ -47,7 +47,12 @@ jobs:
             gh pr close -c stale "$PR";
           elif [[ -z "$PR" && -n "$CHANGES" ]]; then
             echo "Opening new PR"
-            gh pr create --base main --head auto-update-external-charm-pins --title "chore: update charm pins" --body "This is an automated PR to update pins of the external repositories that the operator framework is tested against";
+            gh pr create \
+               --base main \
+               --head auto-update-external-charm-pins \
+               --reviewer benhoyt,tonyandrewmeyer,ironcore864,dimaqq \
+               --title "chore: update charm pins" \
+               --body "This is an automated PR to update pins of the external repositories that the operator framework is tested against";
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATE_CHARM_PINS_ACCESS_TOKEN }}


### PR DESCRIPTION
Tag reviewers explicitly, since:
- we're not using CODEOWNERS
- tagging a group kinda "dimisses" the reviewer group setting after 1 review, when we need 2 reviews to merge