### PR TITLE
chore: address review comments

### DIFF
--- a/.github/workflows/publish-ops-scenario.yaml
+++ b/.github/workflows/publish-ops-scenario.yaml
@@ -2,7 +2,7 @@ name: Publish (ops-scenario)
 on:
   push:
     tags:
-      - 'scenario-7.*'
+      - '2.*'
 
 jobs:
   framework-tests:

--- a/.github/workflows/publish-ops-tracing.yaml
+++ b/.github/workflows/publish-ops-tracing.yaml
@@ -1,5 +1,8 @@
 name: Publish (ops-tracing)
-on: [workflow_call, workflow_dispatch]
+on:
+  push:
+    tags:
+      - '2.*'
 
 jobs:
   framework-tests:

--- a/HACKING.md
+++ b/HACKING.md
@@ -362,26 +362,25 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    Charm-Tech team proofread it.
 9. Format the auto-generated release notes according to the `CHANGES.md` section below,
    and add it to `CHANGES.md`.
-10. For `ops`, change [version.py](ops/version.py)'s `version` to the
-   appropriate string. For `ops-scenario`, change the version in
-   [testing/pyproject.toml](testing/pyproject.toml). We use both
-   [semantic versioning](https://semver.org/) and lockstep releases, so if
-   one library requires a version bump, the other will too.
-   The minor and patch versions should therefore be identical.
-11. Bump the `ops-scenario` version required by `ops[testing]` in [pyproject.toml](pyproject.toml)
-    to == the new `ops-scenario` version being released. Bump the version of `ops` required by
-    `ops-scenario` in [testing/pyproject.toml](testing/pyproject.toml) to == the new `ops` version
-    being released.
-12. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
+10. Change the versions for `ops`, `ops-scenario` and `ops-tracing` to the versions
+   being released: `ops==2.xx.y, ops-tracing==2.xx.y, ops-scenario==7.xx.y`.
+   We use both [semantic versioning](https://semver.org/) and lockstep releases, so if
+   one library requires a version bump, the other will too. There will be a total of
+   seven changes:
+   - in [ops/version.py for `ops`](ops/version.py), the version declared in the `version` variable
+   - in [pyroject.toml for `ops`](pyproject.toml), the required versions for `ops-scenario` and `ops-tracing`
+   - in [pyproject.toml for `ops-scenario`](testing/pyproject.toml), the `version` attribute and the required version for `ops`
+   - in [pyproject.toml for `ops-tracing`](tracing/pyproject.toml), the `version` attribute and the required version for `ops`
+11. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
    using the same Python version as specified in the `.readthedocs.yaml` file.
-13. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
+12. Add, commit, and push, and open a PR to get the `CHANGES.md` update, version bumps,
    and doc requirement bumps into main (and get it merged).
-14. Push a new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
+13. Push a new tag in the form `scenario-<major>.<minor>.<patch>`. This is done by
    executing `git tag scenario-x.y.z`, then `git push upstream tag scenario-x.y.z` locally
    (assuming you have configured `canonical/operator` as a remote named
    `upstream`).
-15. When you are ready, click "Publish". GitHub will create the additional tag.
+14. When you are ready, click "Publish". GitHub will create the additional tag.
 
     Pushing the tags will trigger automatic builds for the Python packages and
     publish them to PyPI ([ops](https://pypi.org/project/ops/) and
@@ -394,13 +393,16 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
     (Note that the versions in the YAML refer to versions of the GitHub actions, not the versions of the ops  library.)
 
     You can troubleshoot errors on the [Actions Tab](https://github.com/canonical/operator/actions).
-
-16. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42) and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
-
-17. Open a PR to change the version strings to the expected next version, with ".dev0" appended
-   (for example, if 3.14.0 is the next expected `ops` version, use `'3.14.0.dev0'`).
-   In this PR, also update the requirements in the respective pyproject.toml files to be == these
-   development versions (for example, `ops==3.14.0.dev0` for `ops-scenario`).
+15. Announce the release on [Discourse](https://discourse.charmhub.io/c/framework/42)
+    and [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com).
+16. Open a PR to change the version strings to the expected next version, with ".dev0" appended.
+   For example, if 2.90.0 is the next expected `ops` version, use
+   `ops==2.90.0.dev0 ops-tracing==2.90.0.dev0 ops-scenario==7.90.0.dev0`.
+   There will be a total of seven changes:
+   - in [pyroject.toml for `ops`](pyproject.toml), the required versions for `ops-scenario` and `ops-tracing`
+   - in [ops/version.py for `ops`](ops/version.py), the version declared in the `version` variable
+   - in [pyproject.toml for `ops-scenario`](testing/pyproject.toml), the `version` attribute and the required version for `ops`
+   - in [pyproject.toml for `ops-tracing`](tracing/pyproject.toml), the `version` attribute and the required version for `ops`
 
 ## Release Documentation
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -367,10 +367,10 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    We use both [semantic versioning](https://semver.org/) and lockstep releases, so if
    one library requires a version bump, the other will too. There will be a total of
    seven changes:
-   - in [ops/version.py for `ops`](ops/version.py), the version declared in the `version` variable
-   - in [pyroject.toml for `ops`](pyproject.toml), the required versions for `ops-scenario` and `ops-tracing`
-   - in [pyproject.toml for `ops-scenario`](testing/pyproject.toml), the `version` attribute and the required version for `ops`
-   - in [pyproject.toml for `ops-tracing`](tracing/pyproject.toml), the `version` attribute and the required version for `ops`
+    - in [ops/version.py for `ops`](ops/version.py), the version declared in the `version` variable
+    - in [pyroject.toml for `ops`](pyproject.toml), the required versions for `ops-scenario` and `ops-tracing`
+    - in [pyproject.toml for `ops-scenario`](testing/pyproject.toml), the `version` attribute and the required version for `ops`
+    - in [pyproject.toml for `ops-tracing`](tracing/pyproject.toml), the `version` attribute and the required version for `ops`
 11. Run `uvx -p 3.11 tox -e docs-deps` to recompile the `requirements.txt` file
    used for docs (in case dependencies have been updated in `pyproject.toml`)
    using the same Python version as specified in the `.readthedocs.yaml` file.
@@ -399,10 +399,10 @@ To make a release of the `ops` and/or `ops-scenario` packages, do the following:
    For example, if 2.90.0 is the next expected `ops` version, use
    `ops==2.90.0.dev0 ops-tracing==2.90.0.dev0 ops-scenario==7.90.0.dev0`.
    There will be a total of seven changes:
-   - in [pyroject.toml for `ops`](pyproject.toml), the required versions for `ops-scenario` and `ops-tracing`
-   - in [ops/version.py for `ops`](ops/version.py), the version declared in the `version` variable
-   - in [pyproject.toml for `ops-scenario`](testing/pyproject.toml), the `version` attribute and the required version for `ops`
-   - in [pyproject.toml for `ops-tracing`](tracing/pyproject.toml), the `version` attribute and the required version for `ops`
+    - in [pyroject.toml for `ops`](pyproject.toml), the required versions for `ops-scenario` and `ops-tracing`
+    - in [ops/version.py for `ops`](ops/version.py), the version declared in the `version` variable
+    - in [pyproject.toml for `ops-scenario`](testing/pyproject.toml), the `version` attribute and the required version for `ops`
+    - in [pyproject.toml for `ops-tracing`](tracing/pyproject.toml), the `version` attribute and the required version for `ops`
 
 ## Release Documentation
 

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -341,6 +341,8 @@ from .model import (
 from .version import version as __version__
 
 try:
+    # Note that ops_tracing vendors charm libs that depend on ops.
+    # We import it last, after all re-exported symbols.
     import ops_tracing as tracing
 except ImportError:
     tracing = None

--- a/tracing/ops_tracing/__init__.py
+++ b/tracing/ops_tracing/__init__.py
@@ -77,10 +77,12 @@ from ._api import Tracing
 from ._backend import mark_observed as _mark_observed
 from ._backend import set_destination
 from ._backend import setup as _setup
+from ._backend import shutdown as _shutdown
 
 __all__ = [
     'Tracing',
     '_mark_observed',
     '_setup',
+    '_shutdown',
     'set_destination',
 ]

--- a/tracing/ops_tracing/_api.py
+++ b/tracing/ops_tracing/_api.py
@@ -27,9 +27,6 @@ from .vendor.charms.certificate_transfer_interface.v1.certificate_transfer impor
 from .vendor.charms.tempo_coordinator_k8s.v0.tracing import (
     AmbiguousRelationUsageError,
     ProtocolNotRequestedError,
-    RelationInterfaceMismatchError,
-    RelationNotFoundError,
-    RelationRoleMismatchError,
     TracingEndpointRequirer,
 )
 
@@ -115,19 +112,11 @@ class Tracing(ops.Object):
                 f"{tracing_relation_name=} {relation.interface_name=} when 'tracing' is expected"
             )
 
-        try:
-            self._tracing = TracingEndpointRequirer(
-                self.charm,
-                tracing_relation_name,
-                protocols=['otlp_http'],
-            )
-        except (
-            RelationInterfaceMismatchError,
-            RelationNotFoundError,
-            RelationRoleMismatchError,
-            TypeError,
-        ) as e:
-            raise ValueError(str(e)) from None
+        self._tracing = TracingEndpointRequirer(
+            self.charm,
+            tracing_relation_name,
+            protocols=['otlp_http'],
+        )
 
         for event in (
             self.charm.on.start,

--- a/tracing/ops_tracing/_backend.py
+++ b/tracing/ops_tracing/_backend.py
@@ -14,9 +14,8 @@
 
 from __future__ import annotations
 
-import contextlib
 import pathlib
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -33,8 +32,7 @@ BUFFER_FILENAME: str = '.tracing-data.db'
 """Name of the file whither data is buffered, located next to .unit-state.db."""
 
 
-@contextlib.contextmanager
-def setup(juju_context: _JujuContext, charm_class_name: str) -> Generator[None, None, None]:
+def setup(juju_context: _JujuContext, charm_class_name: str) -> None:
     """Control tracing lifespan of tracing.
 
     Args:
@@ -54,10 +52,6 @@ def setup(juju_context: _JujuContext, charm_class_name: str) -> Generator[None, 
         }
     )
     set_tracer_provider(_create_provider(resource, juju_context.charm_dir))
-    try:
-        yield
-    finally:
-        shutdown_tracing()
 
 
 def _create_provider(resource: Resource, charm_dir: pathlib.Path) -> TracerProvider:
@@ -110,7 +104,7 @@ def mark_observed() -> None:
     exporter.buffer.mark_observed()
 
 
-def shutdown_tracing() -> None:
+def shutdown() -> None:
     """Shutdown tracing, which is expected to flush the buffered data out."""
     provider = get_tracer_provider()
     if isinstance(provider, TracerProvider):

--- a/tracing/ops_tracing/_backend.py
+++ b/tracing/ops_tracing/_backend.py
@@ -33,7 +33,7 @@ BUFFER_FILENAME: str = '.tracing-data.db'
 
 
 def setup(juju_context: _JujuContext, charm_class_name: str) -> None:
-    """Control tracing lifespan of tracing.
+    """Set up the tracing subsystem and configure OpenTelemetry.
 
     Args:
         juju_context: the context for this dispatch, for annotation

--- a/tracing/ops_tracing/_mock.py
+++ b/tracing/ops_tracing/_mock.py
@@ -29,6 +29,11 @@ from . import _backend
 
 @contextlib.contextmanager
 def patch_tracing() -> Generator[None, None, None]:
+    """Patch ops[tracing] for unit tests.
+
+    Replaces the real buffer and exporter with an in-memory store.
+    This effectively removes the requirement for unique directories for each unit test.
+    """
     # OTEL tries hard to prevent tracing provider from being set twice
     real_otel_provider = opentelemetry.trace._TRACER_PROVIDER
     real_otel_once_done = opentelemetry.trace._TRACER_PROVIDER_SET_ONCE._done
@@ -48,6 +53,3 @@ def _create_provider(resource: Resource, charm_dir: pathlib.Path) -> TracerProvi
         resource=resource,
         active_span_processor=SimpleSpanProcessor(InMemorySpanExporter()),  # type: ignore
     )
-
-
-__all__ = ['_create_provider']

--- a/tracing/test/conftest.py
+++ b/tracing/test/conftest.py
@@ -24,7 +24,7 @@ import ops.testing
 import pytest
 from ops.jujucontext import _JujuContext
 
-from ops_tracing import _setup
+import ops_tracing
 
 
 @pytest.fixture
@@ -78,8 +78,9 @@ def juju_context(tmp_path: pathlib.Path):
 
 @pytest.fixture
 def setup_tracing(juju_context: _JujuContext):
-    with _setup(juju_context, 'charm'):
-        yield
+    ops_tracing._setup(juju_context, 'charm')
+    yield
+    ops_tracing._shutdown()
     # Note that OpenTelemetry disallows setting the tracer provider twice,
     # a warning is issued and new provider is ignored.
     # For example, we could reset the resource instead:


### PR DESCRIPTION
Is `tracer = xxx` same as `logger = getLogger()`?
tracer
opentelemetry.trace
Be careful about other things re-exported

Synchronised ops==ops-tracing==ops-scenario
yes

Explain circular import
Nothing to do

Current take on log ←→ traces correlation
Remove log to event promotion

Hiding vendored exceptions
Remove extra try/except

Context manager for tracing._setup()
Recode tracing._setup
Keep start_as_current_tarce().__enter__

Beta or Stable classifier for ops-tracing
Stable is ok
